### PR TITLE
ci: use official Docker Buildx action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   IMAGE_NAME: dwight-bot
-  IMAGE_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
+  IMAGE_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
 
 jobs:
   test:
@@ -39,14 +39,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
-        with:
-          buildx-version: latest
-          qemu-version: latest
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+        uses: docker/setup-buildx-action@v1
       - name: Build image
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME


### PR DESCRIPTION
The old buildx step that we were using is deprecated, migrate to official action

fixes #65