### PR TITLE
ci(actions): cancel previous runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.2
         with:


### PR DESCRIPTION
Because building the docker images takes a while to build, we want to cancel any current runs if something gets merged in before it completes. This happens a lot with dependabot