### PR TITLE
feat(commands): allow arguments to be parsed with regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2057,6 +2057,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -2066,22 +2067,26 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -2092,6 +2097,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -2588,7 +2594,8 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -3352,7 +3359,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -6676,7 +6684,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -8211,6 +8220,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -8220,12 +8230,14 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -8234,6 +8246,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -8241,22 +8254,26 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -8267,6 +8284,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -8325,6 +8343,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -8338,22 +8357,26 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -8364,19 +8387,22 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
         },
         "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
         },
         "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "dotenv": "^8.2.0",
     "joi": "^17.4.0",
     "lodash": "^4.17.21",
-    "pino": "^6.11.3",
-    "yargs": "^16.2.0"
+    "pino": "^6.11.3"
   },
   "devDependencies": {
     "@tsconfig/node14": "^1.0.0",

--- a/src/commands/35.test.ts
+++ b/src/commands/35.test.ts
@@ -12,18 +12,16 @@ jest.mock('discord.js', () => ({
     Guild: jest.fn(),
     TextChannel: jest.fn(),
     Collection: jest.fn(),
-    Message: jest.fn().mockImplementation(() => {
-        return {
-            reply: mocks.reply,
-        };
-    }),
+    Message: jest.fn().mockImplementation(() => ({
+        reply: mocks.reply,
+    })),
 }));
 
 describe('_3.5 configuration', () => {
     it('should have basic command infomation', () => {
         expect(command.name).toEqual('3.5');
         expect(command.description).toEqual('3.5 to 5th edition skills conversion');
-        expect(command.usage).toEqual('SKILL');
+        expect(command.usage).toEqual('<skill>');
     });
 
     it('should have aliases', () => {
@@ -45,11 +43,11 @@ describe('_3.5', () => {
     });
 
     it.each([
-        [['use', 'rope'], 'DEX (Acrobatics)'],
-        [['Use', 'Magic', 'Device'], 'INT (Arcana)'],
-        [['Ride'], 'WIS (Animal Handling) or DEX (Acrobatics)'],
-    ])('returns a comprable 5e skill for %s', async (search, result) => {
-        await command.run(message, { $0: '3.5', _: search });
+        ['use rope', 'DEX (Acrobatics)'],
+        ['Use Magic Device', 'INT (Arcana)'],
+        ['Ride', 'WIS (Animal Handling) or DEX (Acrobatics)'],
+    ])('returns a comprable 5e skill for %s', async (skill, result) => {
+        await command.run(message, { command: '3.5', args: [], match: [], groups: { skill } });
 
         expect(mocks.reply).toHaveBeenCalledTimes(1);
         expect(mocks.reply).toHaveBeenCalledWith(result);
@@ -61,7 +59,7 @@ describe('_3.5', () => {
 
     it('throws an error on invalid skill', async () => {
         try {
-            await command.run(message, { $0: '3.5', _: ['foo'] });
+            await command.run(message, { command: '3.5', args: [], match: [], groups: { skill: 'foo' } });
 
             fail('expected error to be thrown');
         } catch (err) {

--- a/src/commands/35.ts
+++ b/src/commands/35.ts
@@ -1,6 +1,3 @@
-import { Message } from 'discord.js';
-import { Arguments } from 'yargs';
-
 import { FriendlyError } from '../error';
 import { Command, Dictionary } from '../types';
 
@@ -45,11 +42,12 @@ export const conversion: Dictionary<string> = {
 
 const command: Command = {
     name: '3.5',
-    description: '3.5 to 5th edition skills conversion',
     alias: ['35'],
-    usage: 'SKILL',
-    async run(message: Message, args: Arguments): Promise<Message> {
-        const search = args._.join(' ');
+    args: /(?<skill>.+)/,
+    description: '3.5 to 5th edition skills conversion',
+    usage: '<skill>',
+    async run(message, { groups }) {
+        const search = groups.skill?.trim();
         const skill = conversion[search.toLowerCase()];
         if (!skill) {
             throw new FriendlyError(`I couldn't find skill "${search}".`);

--- a/src/commands/__snapshots__/index.test.ts.snap
+++ b/src/commands/__snapshots__/index.test.ts.snap
@@ -6,7 +6,7 @@ exports[`_help returns a list of all commands 1`] = `
     Array [
       Array [
         "Here is a list of available commands:",
-        "help, 3.5, elixir, event, item, madness, ping, prune, spell, table, treasure, wild",
+        "help, 3.5, elixir, event, item, madness, ping, prune, spell, table, treasure, wild magic",
         "Get more details with \\"_help [command]\\"",
       ],
       Object {
@@ -23,7 +23,7 @@ exports[`_help returns a list of all commands 1`] = `
             Array [
               Array [
                 "Here is a list of available commands:",
-                "help, 3.5, elixir, event, item, madness, ping, prune, spell, table, treasure, wild",
+                "help, 3.5, elixir, event, item, madness, ping, prune, spell, table, treasure, wild magic",
                 "Get more details with \\"_help [command]\\"",
               ],
               Object {
@@ -80,8 +80,8 @@ exports[`_help returns the details for the help command 1`] = `
     Array [
       Array [
         "**help**: Get help with commands",
-        "*aliases*: commands",
-        "*usage*: \`_help [COMMAND]\`",
+        "*aliases*: commands, usage",
+        "*usage*: \`_help [command]\`",
       ],
       Object {
         "split": true,
@@ -97,8 +97,8 @@ exports[`_help returns the details for the help command 1`] = `
             Array [
               Array [
                 "**help**: Get help with commands",
-                "*aliases*: commands",
-                "*usage*: \`_help [COMMAND]\`",
+                "*aliases*: commands, usage",
+                "*usage*: \`_help [command]\`",
               ],
               Object {
                 "split": true,
@@ -120,8 +120,8 @@ exports[`_help returns the details for the treasure command 1`] = `
       Array [
         "**treasure**: Give me the loot!",
         "*aliases*: loot",
-        "*usage*: \`_treasure CR [ROLL] [--hoard]\`",
-        "*examples*: \`_treasure 4\`, \`_treasure 6 86\`, \`_treasure 10 --hoard\`",
+        "*usage*: \`_treasure [hoard] <cr> [d100]\`",
+        "*examples*: \`_treasure 4\`, \`_treasure 6 86\`, \`_treasure hoard 10\`",
       ],
       Object {
         "split": true,
@@ -138,8 +138,8 @@ exports[`_help returns the details for the treasure command 1`] = `
               Array [
                 "**treasure**: Give me the loot!",
                 "*aliases*: loot",
-                "*usage*: \`_treasure CR [ROLL] [--hoard]\`",
-                "*examples*: \`_treasure 4\`, \`_treasure 6 86\`, \`_treasure 10 --hoard\`",
+                "*usage*: \`_treasure [hoard] <cr> [d100]\`",
+                "*examples*: \`_treasure 4\`, \`_treasure 6 86\`, \`_treasure hoard 10\`",
               ],
               Object {
                 "split": true,

--- a/src/commands/elixir.test.ts
+++ b/src/commands/elixir.test.ts
@@ -12,12 +12,10 @@ jest.mock('discord.js', () => ({
     Guild: jest.fn(),
     TextChannel: jest.fn(),
     Collection: jest.fn(),
-    Message: jest.fn().mockImplementation(() => {
-        return {
-            delete: mocks.delete,
-            reply: mocks.reply,
-        };
-    }),
+    Message: jest.fn().mockImplementation(() => ({
+        delete: mocks.delete,
+        reply: mocks.reply,
+    })),
 }));
 
 describe('_elixir configuration', () => {
@@ -46,28 +44,20 @@ describe('_elixir', () => {
     });
 
     it('returns an elixir', async () => {
-        const reply = await command.run(message, { $0: 'elixir', _: [] });
+        await command.run(message, { command: 'elixir', args: [], match: [], groups: {} });
 
         expect(mocks.delete).toHaveBeenCalledTimes(1);
-        expect(reply).toBe(message);
 
         const elixir = mocks.reply.mock.calls[0][0];
         expect(elixirs).toContainEqual(elixir);
     });
 
     it('returns an elixir for a dice roll', async () => {
-        const one = await command.run(message, { $0: 'elixir', _: ['1'] });
-        const two = await command.run(message, { $0: 'elixir', _: [], roll: 4 });
+        await command.run(message, { command: 'elixir', args: [], match: [], groups: { roll: '1' } });
 
-        expect(mocks.delete).toHaveBeenCalledTimes(2);
-        expect(one).toBe(message);
-        expect(two).toBe(message);
-
+        expect(mocks.delete).toHaveBeenCalledTimes(1);
         expect(mocks.reply).toHaveBeenCalledWith(
             '**Healing**. The drinker regains a number of hit points equal to 2d4 + your Intelligence modifier.',
-        );
-        expect(mocks.reply).toHaveBeenCalledWith(
-            '**Boldness**. The drinker can roll a d4 and add the number rolled to every attack roll and saving throw they make for the next minute.',
         );
     });
 });

--- a/src/commands/elixir.ts
+++ b/src/commands/elixir.ts
@@ -1,6 +1,3 @@
-import { Message } from 'discord.js';
-import { Arguments } from 'yargs';
-
 import { Command } from '../types';
 import { roll } from '../utils';
 
@@ -16,9 +13,11 @@ export const elixirs = [
 const command: Command = {
     name: 'elixir',
     alias: ['elx'],
+    args: /(?<roll>\d+)?/,
     description: 'Craft an experimental elixir',
-    async run(message: Message, args: Arguments): Promise<Message> {
-        const dice = Number(args.roll || args._[0] || roll('d6'));
+    usage: '[d6]',
+    async run(message, { groups }) {
+        const dice = Number(groups.roll || roll('d6'));
         const result = elixirs[dice - 1];
 
         await message.delete();

--- a/src/commands/event.test.ts
+++ b/src/commands/event.test.ts
@@ -12,14 +12,12 @@ jest.mock('discord.js', () => ({
     Guild: jest.fn(),
     TextChannel: jest.fn(),
     Collection: jest.fn(),
-    Message: jest.fn().mockImplementation(() => {
-        return {
-            delete: mocks.delete,
-            channel: {
-                send: mocks.send,
-            },
-        };
-    }),
+    Message: jest.fn().mockImplementation(() => ({
+        delete: mocks.delete,
+        channel: {
+            send: mocks.send,
+        },
+    })),
 }));
 
 describe('_event configuration', () => {
@@ -48,10 +46,9 @@ describe('_event', () => {
     });
 
     it('returns a random event', async () => {
-        const reply = await command.run(message, { $0: 'event', _: [] });
+        await command.run(message, { command: 'event', args: [], match: [], groups: {} });
 
         expect(mocks.delete).toHaveBeenCalledTimes(1);
-        expect(reply).toBe(message.channel);
 
         const event = mocks.send.mock.calls[0][0];
         expect(events).toContainEqual(event);

--- a/src/commands/event.ts
+++ b/src/commands/event.ts
@@ -1,4 +1,3 @@
-import { Message } from 'discord.js';
 import { sample } from 'lodash';
 
 import { Command } from '../types';
@@ -29,7 +28,7 @@ export const events = [
 const command: Command = {
     name: 'event',
     description: 'Trigger a random event',
-    async run(message: Message): Promise<Message> {
+    async run(message) {
         await message.delete();
 
         return message.channel.send(sample(events) ?? 'Something happens');

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -11,20 +11,18 @@ jest.mock('discord.js', () => ({
     Client: jest.fn(),
     Guild: jest.fn(),
     TextChannel: jest.fn(),
-    Message: jest.fn().mockImplementation(() => {
-        return {
-            channel: {
-                send: mocks.send,
-            },
-        };
-    }),
+    Message: jest.fn().mockImplementation(() => ({
+        channel: {
+            send: mocks.send,
+        },
+    })),
 }));
 
 describe('_help configuration', () => {
     it('should have basic command infomation', () => {
         expect(help.name).toEqual('help');
         expect(help.description).toEqual('Get help with commands');
-        expect(help.usage).toEqual('[COMMAND]');
+        expect(help.usage).toEqual('[command]');
     });
 
     it('should have an alias', () => {
@@ -46,22 +44,18 @@ describe('_help', () => {
     });
 
     it('returns a list of all commands', async () => {
-        const reply = await help.run(message, { $0: 'help', _: [] });
-
-        expect(reply).toEqual(message.channel);
+        await help.run(message, { command: 'help', args: [], match: [], groups: {} });
         expect(mocks.send).toMatchSnapshot();
     });
 
     it.each(['help', 'treasure', 'event'])('returns the details for the %s command', async (cmd) => {
-        const reply = await help.run(message, { $0: 'help', _: [cmd] });
-
-        expect(reply).toEqual(message.channel);
+        await help.run(message, { command: 'help', args: [cmd], match: [], groups: {} });
         expect(mocks.send).toMatchSnapshot();
     });
 
     it('returns an error if an invalid command is given', async () => {
         try {
-            await help.run(message, { $0: 'help', _: ['invalid'] });
+            await help.run(message, { command: 'help', args: ['invalid'], match: [], groups: {} });
 
             fail('expected error to be thrown');
         } catch (err) {
@@ -74,10 +68,11 @@ describe('_help', () => {
 describe('Commands', () => {
     it('registers commands and their aliases', () => {
         const commands = new Commands();
-        expect(commands.list()).toHaveLength(0);
+        expect(commands.list()).toEqual([]);
 
         commands.register(help);
-        expect(commands.list()).toHaveLength(1);
+        expect(commands.list()).toEqual(['help']);
+        expect(commands.all()).toEqual(['help', 'commands', 'usage']);
     });
 
     it('returns the correct command', () => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,3 @@
-import { Message } from 'discord.js';
-import { Arguments } from 'yargs';
-
 import config from '../config';
 import { FriendlyError } from '../error';
 import { Command } from '../types';
@@ -30,15 +27,19 @@ export class Commands {
     list(): string[] {
         return this.commands.map((c) => c.name);
     }
+
+    all(): string[] {
+        return this.commands.flatMap((c) => [c.name, ...(c.alias || [])]);
+    }
 }
 
 export const help: Command = {
     name: 'help',
     description: 'Get help with commands',
-    alias: ['commands'],
-    usage: '[COMMAND]',
-    async run(message: Message, args: Arguments): Promise<Message | Message[]> {
-        if (!args._.length) {
+    alias: ['commands', 'usage'],
+    usage: '[command]',
+    async run(message, { args }) {
+        if (!args.length) {
             return message.channel.send(
                 [
                     'Here is a list of available commands:',
@@ -49,7 +50,7 @@ export const help: Command = {
             );
         }
 
-        const name = args._[0].toString().toLowerCase();
+        const name = args[0].toString().toLowerCase();
         const command = commands.get(name);
 
         if (!command) {

--- a/src/commands/item.ts
+++ b/src/commands/item.ts
@@ -1,6 +1,4 @@
-import { Message } from 'discord.js';
 import { sample } from 'lodash';
-import { Arguments } from 'yargs';
 
 import itemList from '../data/items';
 import { FriendlyError } from '../error';
@@ -10,16 +8,15 @@ const command: Command = {
     name: 'item',
     description: 'Return a random magic item',
     alias: ['items'],
-    usage: '[--rarity] RARITY [--type] TYPE',
-    examples: ['rare', 'rare weapon', '--type weapon'],
-    async run(message: Message, args: Arguments): Promise<Message> {
-        const rarity = (args.rarity || args._[0]) as string;
-        const type = (args.type || args._[1]) as string;
+    args: /(?<rarity>common|uncommon|rare|very rare|legendary|artifact)? ?(?<type>\w+)?/,
+    usage: '[rarity] [type]',
+    examples: ['rare', 'rare weapon', 'weapon'],
+    async run(message, { groups }) {
+        const { rarity, type } = groups;
 
         let items = await itemList();
         if (rarity) {
-            const rarityFilter = rarity.toLowerCase() === 'vrare' ? 'very rare' : rarity.toLowerCase();
-            items = items.filter((i) => i.rarity.toLowerCase() === rarityFilter);
+            items = items.filter((i) => i.rarity.toLowerCase() === rarity.toLowerCase());
         }
 
         if (type) {

--- a/src/commands/madness.ts
+++ b/src/commands/madness.ts
@@ -1,6 +1,4 @@
-import { Message } from 'discord.js';
 import { sample } from 'lodash';
-import { Arguments } from 'yargs';
 
 import { FriendlyError } from '../error';
 import { Command, Dictionary } from '../types';
@@ -102,10 +100,12 @@ export const madness: Dictionary<Madness> = {
 
 const command: Command = {
     name: 'madness',
+    alias: ['flaw'],
+    args: /(?<type>short|long)?/,
     description: 'Give a random madness to a player',
-    usage: '[short|long|flaw] ...@user',
-    async run({ mentions, author }: Message, args: Arguments) {
-        const type = (args._[0] || 'short').toString().toLowerCase();
+    usage: '[short|long|flaw] <...@user>',
+    async run({ mentions, author }, { command, groups }) {
+        const type = (command === 'flaw' ? 'flaw' : groups.type || 'short').toLowerCase();
         const users = mentions.users.filter((u) => !u.bot);
         if (0 === users.size) {
             throw new FriendlyError('You must assign a madness to a user.');

--- a/src/commands/ping.test.ts
+++ b/src/commands/ping.test.ts
@@ -3,7 +3,7 @@ import { Client, Guild, Message, TextChannel } from 'discord.js';
 import command from './ping';
 
 const mocks = {
-    send: jest.fn(),
+    react: jest.fn(),
 };
 
 jest.mock('discord.js', () => ({
@@ -11,13 +11,9 @@ jest.mock('discord.js', () => ({
     Guild: jest.fn(),
     TextChannel: jest.fn(),
     Collection: jest.fn(),
-    Message: jest.fn().mockImplementation(() => {
-        return {
-            channel: {
-                send: mocks.send,
-            },
-        };
-    }),
+    Message: jest.fn().mockImplementation(() => ({
+        react: mocks.react,
+    })),
 }));
 
 describe('_ping configuration', () => {
@@ -35,8 +31,7 @@ describe('_ping', () => {
     let message: Message;
 
     beforeEach(() => {
-        mocks.send.mockClear();
-        mocks.send.mockReturnThis();
+        mocks.react.mockClear();
 
         const client = new Client();
         const guild = new Guild(client, {});
@@ -45,8 +40,7 @@ describe('_ping', () => {
     });
 
     it('responds', async () => {
-        await command.run(message, { $0: 'ping', _: [] });
-
-        expect(mocks.send).toBeCalledWith('pong');
+        await command.run(message, { command: 'ping', args: [], match: [], groups: {} });
+        expect(mocks.react).toBeCalledWith('🏓');
     });
 });

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,12 +1,10 @@
-import { Message } from 'discord.js';
-
 import { Command } from '../types';
 
 const command: Command = {
     name: 'ping',
     description: 'Pong',
-    async run({ channel }: Message): Promise<Message> {
-        return channel.send('pong');
+    async run(message) {
+        return message.react('🏓');
     },
 };
 

--- a/src/commands/prune.test.ts
+++ b/src/commands/prune.test.ts
@@ -12,21 +12,19 @@ jest.mock('discord.js', () => ({
     Guild: jest.fn(),
     TextChannel: jest.fn(),
     Collection: jest.fn(),
-    Message: jest.fn().mockImplementation(() => {
-        return {
-            channel: {
-                type: 'text',
-                bulkDelete: mocks.delete,
-            },
-        };
-    }),
+    Message: jest.fn().mockImplementation(() => ({
+        channel: {
+            type: 'text',
+            bulkDelete: mocks.delete,
+        },
+    })),
 }));
 
 describe('_prune configuration', () => {
     it('should have basic command infomation', () => {
         expect(command.name).toEqual('prune');
         expect(command.description).toEqual('Prune messages from a channel');
-        expect(command.usage).toEqual('COUNT');
+        expect(command.usage).toEqual('<count>');
     });
 
     it('should have a purge alias', () => {
@@ -47,8 +45,7 @@ describe('_ping', () => {
     });
 
     it('deletes messages in text channels', async () => {
-        await command.run(message, { $0: 'prune', _: ['3'] });
-
+        await command.run(message, { command: 'prune', args: ['3'], match: [], groups: {} });
         expect(mocks.delete).toBeCalledWith(4, true);
     });
 
@@ -56,11 +53,10 @@ describe('_ping', () => {
         message.channel.type = 'dm';
 
         try {
-            await command.run(message, { $0: 'prune', _: ['3'] });
-
+            await command.run(message, { command: 'prune', args: [], match: [], groups: {} });
             fail('expected error to be thrown');
         } catch (err) {
-            expect(err instanceof FriendlyError).toBe(true);
+            expect(err).toBeInstanceOf(FriendlyError);
             expect(err.message).toEqual("I can't bulk delete DMs.");
         }
     });

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -1,6 +1,3 @@
-import { Message } from 'discord.js';
-import { Arguments } from 'yargs';
-
 import { FriendlyError } from '../error';
 import { Command } from '../types';
 
@@ -8,13 +5,13 @@ const command: Command = {
     name: 'prune',
     description: 'Prune messages from a channel',
     alias: ['purge'],
-    usage: 'COUNT',
-    async run(message: Message, args: Arguments) {
+    usage: '<count>',
+    async run(message, { args }) {
         if (message.channel.type === 'dm') {
             throw new FriendlyError("I can't bulk delete DMs.");
         }
 
-        await message.channel.bulkDelete(Number(args._[0]) + 1, true);
+        await message.channel.bulkDelete(Number(args[0]) + 1, true);
     },
 };
 

--- a/src/commands/spell.ts
+++ b/src/commands/spell.ts
@@ -1,6 +1,4 @@
-import { Message } from 'discord.js';
 import { sample, upperFirst } from 'lodash';
-import { Arguments } from 'yargs';
 
 import spellList from '../data/spells';
 import { FriendlyError } from '../error';
@@ -10,13 +8,14 @@ const command: Command = {
     name: 'spell',
     description: 'Return a random spell',
     alias: ['spells'],
-    usage: '[--level] LEVEL [--class] CLASS [--school] SCHOOL',
-    examples: ['cantrip', '1 bard', '4 --school illusion'],
-    async run(message: Message, args: Arguments): Promise<Message> {
-        const levelInput = String(args.level ?? args._[0]);
+    args: /(?<level>cantrip|\d(?:[sthnrd]+)?)? ?(?<class>bard|cleric|druid|paladin|ranger|warlock|wizard)? ?(?<school>\w+)?/,
+    usage: '[level] [class] [school]',
+    examples: ['cantrip', '1 bard', '4 illusion'],
+    async run(message, { groups }) {
+        const levelInput = String(groups.level);
         const level = 'cantrip' === levelInput.toLowerCase() ? 0 : Number(levelInput);
-        const type = (args.class || args._[1]) as string;
-        const school = (args.school || args._[2]) as string;
+        const type = groups.class;
+        const school = groups.school;
 
         let spells = await spellList();
         if (!isNaN(level)) {

--- a/src/commands/table.test.ts
+++ b/src/commands/table.test.ts
@@ -28,7 +28,7 @@ describe('_table configuration', () => {
     it('should have basic command infomation', () => {
         expect(command.name).toEqual('table');
         expect(command.description).toEqual('Roll on the magic item tables');
-        expect(command.usage).toEqual('TABLE [ROLL]');
+        expect(command.usage).toEqual('<table> [d100]');
     });
 
     it('should not have an alias', () => {
@@ -50,7 +50,7 @@ describe('_table', () => {
     });
 
     it('returns a value from the given table', async () => {
-        await command.run(message, { $0: 'table', _: ['a'] });
+        await command.run(message, { command: 'table', args: ['a'], match: [], groups: {} });
 
         expect(mocks.delete).toBeCalledTimes(1);
         expect(mocks.reply).toBeCalledTimes(1);
@@ -58,7 +58,7 @@ describe('_table', () => {
     });
 
     it('returns a value for a dice roll', async () => {
-        await command.run(message, { $0: 'table', _: ['b', '99'] });
+        await command.run(message, { command: 'table', args: ['b', '99'], match: [], groups: {} });
 
         expect(mocks.delete).toBeCalledTimes(1);
         expect(mocks.reply).toBeCalledTimes(1);
@@ -66,7 +66,7 @@ describe('_table', () => {
     });
 
     it('returns a resolved value', async () => {
-        await command.run(message, { $0: 'table', _: ['C'] });
+        await command.run(message, { command: 'table', args: ['C'], match: [], groups: {} });
 
         expect(mocks.delete).toBeCalledTimes(1);
         expect(mocks.reply).toBeCalledTimes(1);
@@ -75,10 +75,10 @@ describe('_table', () => {
 
     it('throws an error if invalid table given', async () => {
         try {
-            await command.run(message, { $0: 'table', _: [] });
+            await command.run(message, { command: 'table', args: [], match: [], groups: {} });
             fail('expected error to be thrown');
         } catch (err) {
-            expect(err instanceof FriendlyError).toBe(true);
+            expect(err).toBeInstanceOf(FriendlyError);
             expect(err.message).toEqual('Unknown table "-".');
         }
     });

--- a/src/commands/table.ts
+++ b/src/commands/table.ts
@@ -1,6 +1,4 @@
-import { Message } from 'discord.js';
 import { isString } from 'lodash';
-import { Arguments } from 'yargs';
 
 import magicItemTable from '../data/table';
 import { FriendlyError } from '../error';
@@ -10,10 +8,10 @@ import { roll } from '../utils';
 const command: Command = {
     name: 'table',
     description: 'Roll on the magic item tables',
-    usage: 'TABLE [ROLL]',
-    async run(message: Message, args: Arguments) {
-        const index = (args._[0] || '-').toLowerCase();
-        const dice = Number(args._[1] || roll('d100'));
+    usage: '<table> [d100]',
+    async run(message, { args }) {
+        const index = (args[0] || '-').toLowerCase();
+        const dice = Number(args[1] || roll('d100'));
 
         const table = magicItemTable[index];
         if (!table) {

--- a/src/commands/treasure.ts
+++ b/src/commands/treasure.ts
@@ -1,6 +1,4 @@
-import { Message } from 'discord.js';
 import { isString, sample } from 'lodash';
-import { Arguments } from 'yargs';
 
 import { crIndex, hoard, individual } from '../data/treasure';
 import { FriendlyError } from '../error';
@@ -9,19 +7,20 @@ import { roll } from '../utils';
 
 const command: Command = {
     name: 'treasure',
-    description: 'Give me the loot!',
     alias: ['loot'],
-    usage: 'CR [ROLL] [--hoard]',
-    examples: ['4', '6 86', '10 --hoard'],
-    async run(message: Message, args: Arguments): Promise<Message[]> {
-        const cr = Number(args.cr ?? args._[0]);
-        const dice = Number(args.roll || args._[1] || roll('d100'));
+    args: /(?<hoard>hoard )?(?<cr>\d+)(?<roll> \d+)?/,
+    description: 'Give me the loot!',
+    usage: '[hoard] <cr> [d100]',
+    examples: ['4', '6 86', 'hoard 10'],
+    async run(message, { groups }) {
+        const cr = Number(groups.cr);
+        const dice = Number(groups.roll || roll('d100'));
 
         if (isNaN(cr)) {
             throw new FriendlyError('Missing challenge rating');
         }
 
-        const tables = args.hoard ? hoard : individual;
+        const tables = groups.hoard ? hoard : individual;
         const table = tables[crIndex(cr)][dice - 1];
 
         const reply = ['You found:'];

--- a/src/commands/wildMagic.test.ts
+++ b/src/commands/wildMagic.test.ts
@@ -12,19 +12,17 @@ jest.mock('discord.js', () => ({
     Guild: jest.fn(),
     TextChannel: jest.fn(),
     Collection: jest.fn(),
-    Message: jest.fn().mockImplementation(() => {
-        return {
-            delete: mocks.delete,
-            reply: mocks.reply,
-        };
-    }),
+    Message: jest.fn().mockImplementation(() => ({
+        delete: mocks.delete,
+        reply: mocks.reply,
+    })),
 }));
 
 describe('_wild configuration', () => {
     it('should have basic command infomation', () => {
-        expect(command.name).toEqual('wild');
+        expect(command.name).toEqual('wild magic');
         expect(command.description).toEqual('Roll on the Wild Magic table');
-        expect(command.usage).toEqual('[ROLL]');
+        expect(command.usage).toEqual('[barbarian] [d100|d8]');
     });
 
     it('should have aliases', () => {
@@ -47,26 +45,38 @@ describe('_wild', () => {
     });
 
     it('returns a wild magic event', async () => {
-        const reply = await command.run(message, { $0: 'wild', _: [] });
+        await command.run(message, { command: 'wild', args: [], match: [], groups: {} });
 
         expect(mocks.delete).toHaveBeenCalledTimes(1);
-        expect(reply).toBe(message);
 
         const event = mocks.reply.mock.calls[0][0];
         expect(wildMagic).toContainEqual(event);
     });
 
-    it('returns a wild magic event for a dice roll', async () => {
-        const one = await command.run(message, { $0: 'wild', _: ['89'] });
-        const two = await command.run(message, { $0: 'wild', _: [], roll: 97 });
-
-        expect(mocks.delete).toHaveBeenCalledTimes(2);
-        expect(one).toBe(message);
-        expect(two).toBe(message);
-
+    it('returns a barbarian wild magic event', async () => {
+        await command.run(message, {
+            command: 'wild',
+            args: [],
+            match: [],
+            groups: { barbarian: 'barbarian', roll: '7' },
+        });
+        expect(mocks.delete).toHaveBeenCalledTimes(1);
         expect(mocks.reply).toHaveBeenCalledWith(
+            'Flowers and vines temporarily grow around you; until your rage ends, the ground within 15 feet of you is difficult terrain for your enemies.',
+        );
+    });
+
+    it('returns a wild magic event for a dice roll', async () => {
+        await command.run(message, { command: 'wild', args: [], match: [], groups: { roll: '89' } });
+        expect(mocks.reply).toHaveBeenLastCalledWith(
             'You become invisible for the next minute. During that time, other creatures can’t hear you. The invisibility ends if you attack or cast a spell.',
         );
-        expect(mocks.reply).toHaveBeenCalledWith('You are surrounded by faint, ethereal music for the next minute.');
+
+        await command.run(message, { command: 'wild', args: [], match: [], groups: { roll: '97' } });
+        expect(mocks.reply).toHaveBeenLastCalledWith(
+            'You are surrounded by faint, ethereal music for the next minute.',
+        );
+
+        expect(mocks.delete).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/commands/wildMagic.ts
+++ b/src/commands/wildMagic.ts
@@ -1,6 +1,3 @@
-import { Message } from 'discord.js';
-import { Arguments } from 'yargs';
-
 import { Command } from '../types';
 import { roll } from '../utils';
 
@@ -56,18 +53,36 @@ export const wildMagic = [
     'You are surrounded by faint, ethereal music for the next minute.',
     'You regain all expended sorcery points.',
 ];
+const wildMagicBarbarian = [
+    'Shadowy tendrils lash around you. Each creature of your choice that you can see within 30 feet of you must succeed on a Constitution saving throw or take 1d12 necrotic damage. You also gain 1d12 temporary hit points.',
+    'You teleport up to 30 feet to an unoccupied space you can see. Until your rage ends, you can use this effect again on each of your turns as a bonus action.',
+    'An intangible spirit, which looks like a flumph or a pixie (your choice), appears within 5 feet of one creature of your choice that you can see within 30 feet of you. At the end of the current turn, the spirit explodes, and each creature within 5 feet of it must succeed on a Dexterity saving throw or take 1d6 force damage. Until your rage ends, you can use this effect again, summoning another spirit, on each of your turns as a bonus action.',
+    'Magic infuses one weapon of your choice that you are holding. Until your rage ends, the weapon’s damage type changes to force, and it gains the light and thrown properties, with a normal range of 20 feet and a long range of 60 feet. If the weapon leaves your hand, the weapon reappears in your hand at the end of the current turn.',
+    'Whenever a creature hits you with an attack roll before your rage ends, that creature takes 1d6 force damage, as magic lashes out in retribution.',
+    'Until your rage ends, you are surrounded by multi­colored, protective lights; you gain a +1 bonus to AC, and while within 10 feet of you, your allies gain the same bonus.',
+    'Flowers and vines temporarily grow around you; until your rage ends, the ground within 15 feet of you is difficult terrain for your enemies.',
+    'A bolt of light shoots from your chest. Another creature of your choice that you can see within 30 feet of you must succeed on a Constitution saving throw or take 1d6 radiant damage and be blinded until the start of your next turn. Until your rage ends, you can use this effect again on each of your turns as a bonus action.',
+];
 
 const command: Command = {
-    name: 'wild',
+    name: 'wild magic',
     description: 'Roll on the Wild Magic table',
-    alias: ['wild-magic'],
-    usage: '[ROLL]',
-    async run(message: Message, args: Arguments): Promise<Message> {
-        const dice = Number(args.roll || args._[0] || roll('d100'));
+    alias: ['wild-magic', 'wild'],
+    args: /(?<barbarian>barbarian )?(?<roll>\d+)?/,
+    usage: '[barbarian] [d100|d8]',
+    async run(message, { groups }) {
+        await message.delete();
+
+        if (groups.barbarian) {
+            const dice = Number(groups.roll || roll('d8')) - 1;
+            const result = wildMagicBarbarian[dice];
+
+            return message.reply(result);
+        }
+
+        const dice = Number(groups.roll || roll('d100'));
         const index = Math.floor((dice - 1) / 2);
         const result = wildMagic[index];
-
-        await message.delete();
 
         return message.reply(result);
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { Message, MessageReaction } from 'discord.js';
-import { Arguments } from 'yargs';
 
 export interface Dictionary<T> {
     [key: string]: T;
@@ -9,7 +8,15 @@ export interface Command {
     name: string;
     description: string;
     alias?: string[];
+    args?: RegExp;
     usage?: string;
     examples?: string[];
-    run(message: Message, args: Arguments): Promise<Message | Message[] | MessageReaction | void>;
+    run(message: Message, context: Context): Promise<Message | Message[] | MessageReaction | void>;
+}
+
+export interface Context {
+    command: string;
+    args: string[];
+    match: string[];
+    groups: Dictionary<string>;
 }


### PR DESCRIPTION
To provide more natural feeling commands and not CLI commands, allow the use of regex to parse command arguments

BREAKING CHANGE: Command run has different arguments